### PR TITLE
Add support for external scanning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,22 @@ LDFLAGS=
 OBJ_FILES=main.c.o
 OBJS=$(addprefix obj/, $(OBJ_FILES))
 
-BIN=libsigscan-test.out
+BIN1=libsigscan-test.out
+BIN2=libsigscan-test-external.out
 
 #-------------------------------------------------------------------------------
 
 .PHONY: clean all
 
-all: $(BIN)
+all: $(BIN1) $(BIN2)
 
 clean:
-	rm -f $(OBJS)
-	rm -f $(BIN)
+	rm -f $(BIN1) $(BIN2)
 
 #-------------------------------------------------------------------------------
 
-$(BIN): $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS)
+$(BIN1): src/main.c
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
 
-obj/%.c.o : src/%.c
-	@mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -c -o $@ $<
+$(BIN2): src/external-test.c
+	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)

--- a/README.org
+++ b/README.org
@@ -10,8 +10,9 @@
 * Description
 
 This library is for matching byte patterns (signatures) in the memory of a
-process. By default, this library only scans the *current* process, but there is
-an [[https://github.com/8dcc/libsigscan/tree/external-scanning][=external-scanning= branch]] that is able to read external memory using
+process.
+
+In this branch, the library is able to read *external memory* using
 =process_vm_readv=.
 
 It only supports linux, since it parses the =/proc/PID/maps= file to get the start

--- a/src/external-test.c
+++ b/src/external-test.c
@@ -1,0 +1,33 @@
+/*
+ * This file should be used for testing libsigscan on external processes.
+ */
+
+#include <stdio.h>
+
+#define SECRET_SZ 100
+
+/* This data would be in the application we are trying to scan. */
+static unsigned char secret[SECRET_SZ] = { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5,
+                                           0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB };
+
+int main(int argc, char** argv) {
+    (void)argc; /* Unused */
+
+    printf("Hello from %s, this is my data:\n", argv[0]);
+
+    for (int i = 0; i < 0xB; i++)
+        printf("%02X ", secret[i]);
+
+    printf("\n\nType anything to overwrite the data...\n");
+
+    char c = 0;
+    for (int i = 0; i < SECRET_SZ; i++) {
+        if (i == 0 || c == '\n')
+            printf("[%02d]> ", i);
+
+        secret[i] = c = getchar();
+    }
+
+    printf("You have overwritten the entire array, exiting...\n");
+    return 0;
+}

--- a/src/external-test.c
+++ b/src/external-test.c
@@ -13,9 +13,9 @@ static unsigned char secret[SECRET_SZ] = { 0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5,
 int main(int argc, char** argv) {
     (void)argc; /* Unused */
 
-    printf("Hello from %s, this is my data:\n", argv[0]);
+    printf("Hello from %s, this is my data at %p:\n", argv[0], secret);
 
-    for (int i = 0; i < 0xB; i++)
+    for (int i = 0; i <= 0xB; i++)
         printf("%02X ", secret[i]);
 
     printf("\n\nType anything to overwrite the data...\n");

--- a/src/libsigscan.h
+++ b/src/libsigscan.h
@@ -72,7 +72,7 @@ static bool libsigscan_regex(regex_t expr, const char* str) {
 }
 
 /*
- * Parse /proc/self/maps to get the start and end addresses of the specified
+ * Parse /proc/PID/maps to get the start and end addresses of the specified
  * module.
  *
  * The function assumes the format of maps is always:
@@ -409,7 +409,7 @@ int sigscan_pidof(const char* process_name) {
             continue;
 
         /* See proc_cmdline(5). You can also try:
-         *   cat /proc/self/maps | xxd   */
+         *   cat /proc/PID/cmdline | xxd   */
         sprintf(filename, "/proc/%d/cmdline", pid);
 
         FILE* fd = fopen(filename, "r");

--- a/src/libsigscan.h
+++ b/src/libsigscan.h
@@ -1,9 +1,20 @@
-/**
- * @file   libsigscan.h
- * @brief  Single-header signature scanning library
- * @author 8dcc
+/*
+ * libsigscan.h - Single-header C/C++ library for signature scanning on Linux.
+ * See: https://github.com/8dcc/libsigscan
+ * Copyright (C) 2024 8dcc
  *
- * https://github.com/8dcc/libsigscan
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef LIBSIGSCAN_H_

--- a/src/libsigscan.h
+++ b/src/libsigscan.h
@@ -98,7 +98,7 @@ static LibsigscanModuleBounds* libsigscan_get_module_bounds(int pid,
     /* Open the maps file */
     FILE* fd = fopen(maps_path, "r");
     if (!fd) {
-        LIBSIGSCAN_ERR("Couldn't open /proc/self/maps");
+        LIBSIGSCAN_ERR("Couldn't open /proc/%d/maps", pid);
         return NULL;
     }
 

--- a/src/libsigscan.h
+++ b/src/libsigscan.h
@@ -241,6 +241,23 @@ static void* libsigscan_pid_scan(int pid, void* start, void* end,
     /* TODO: Read from /proc/pid/mem */
     (void)pid;
 
+#if 0
+    static char mem_path[50] = "/proc/self/mem";
+    if (pid != LIBSIGSCAN_PID_SELF)
+        sprintf(mem_path, "/proc/%d/mem", pid);
+
+    /* TODO: Print errors with macro if LIBSIGSCAN_DEBUG is enabled, or add some
+     * kind of libsigscan errno */
+    int fd = open(mem_path, O_RDONLY);
+    if (fd == -1)
+        return NULL;
+
+    if (lseek64(fd, start, SEEK_SET) == -1) {
+        close(fd);
+        return NULL;
+    }
+#endif
+
     /* NOTE: This retarded void* -> char* cast is needed so g++ doesn't generate
      * a warning. */
     uint8_t* start_ptr = (uint8_t*)start;

--- a/src/libsigscan.h
+++ b/src/libsigscan.h
@@ -9,7 +9,9 @@
 #ifndef LIBSIGSCAN_H_
 #define LIBSIGSCAN_H_ 1
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE /* Needed for process_vm_readv() in uio.h */
+#endif
 
 #include <stddef.h>
 #include <stdint.h>
@@ -335,7 +337,7 @@ static void* libsigscan_pid_scan(int pid, uintptr_t start, uintptr_t end,
      * scratch repo:
      *   https://github.com/8dcc/scratch/blob/main/C/misc/buffered-search.c */
     int buf_sz   = strlen(mask);
-    uint8_t* buf = malloc(buf_sz);
+    uint8_t* buf = (uint8_t*)malloc(buf_sz);
     if (libsigscan_read_mem(pid, buf, (void*)start, buf_sz) == NULL)
         return NULL;
 

--- a/src/libsigscan.h
+++ b/src/libsigscan.h
@@ -29,7 +29,9 @@
         fputc('\n', stderr);             \
     } while (0)
 #else
-#define LIBSIGSCAN_ERR(...)
+#define LIBSIGSCAN_ERR(...) \
+    do {                    \
+    } while (0)
 #endif
 
 /*----------------------------------------------------------------------------*/

--- a/src/main.c
+++ b/src/main.c
@@ -43,6 +43,8 @@ int main(void) {
     const char* module_regex;
     void* match;
 
+    printf("Signature: \"%s\"\n", signature);
+
     /* Look for those bytes in all loaded modules. */
     match = sigscan(signature);
     printf("Searching in all modules: %p\n", match);
@@ -56,7 +58,7 @@ int main(void) {
     }
 
     /* Search only in this module. */
-    module_regex = "^.*libsigscan-test\\.out$";
+    module_regex = "^.*libsigscan-test\\.out";
     match        = sigscan_module(module_regex, signature);
     printf("Searching in all modules matching regex \"%s\": %p\n", module_regex,
            match);
@@ -82,19 +84,12 @@ int main(void) {
     }
 
     signature = "A4 A5 A6 ? ? ? AA AB";
+    printf("Signature: \"%s\"\n", signature);
 
     match = sigscan_pid(pid, signature);
     printf("Searching in all modules of PID \"%d\": %p\n", pid, match);
 
-    if (match != NULL) {
-        unsigned char* as_bytes = (unsigned char*)match;
-        printf("First %d bytes: ", 16);
-        for (size_t i = 0; i < 16; i++)
-            printf("0x%02X ", as_bytes[i]);
-        putchar('\n');
-    }
-
-    module_regex = "^.*libsigscan-test-external\\.out$";
+    module_regex = "^.*libsigscan-test-external\\.out";
     match        = sigscan_pid_module(pid, module_regex, signature);
     printf("Searching in all modules of PID \"%d\", that match regex \"%s\": "
            "%p\n",

--- a/src/main.c
+++ b/src/main.c
@@ -65,5 +65,44 @@ int main(void) {
     printf("Searching in all modules matching regex \"%s\": %p\n", module_regex,
            match);
 
+    /*------------------------------------------------------------------------*/
+    /* The following code is used for testing libsigscan on an external
+     * process. */
+
+    printf("\n\n"
+           "Testing in an external process...\n");
+
+    int pid = sigscan_pidof("libsigscan-test-external.out");
+    if (pid == LIBSIGSCAN_PID_INVALID) {
+        printf("External process not running. Make sure you execute "
+               "libsigscan-test-external.out\n");
+        return 0;
+    }
+
+    signature = "A4 A5 A6 ? ? ? AA AB";
+
+    match = sigscan_pid(pid, signature);
+    printf("Searching in all modules of PID \"%d\": %p\n", pid, match);
+
+    if (match != NULL) {
+        unsigned char* as_bytes = (unsigned char*)match;
+        printf("First %d bytes: ", 16);
+        for (size_t i = 0; i < 16; i++)
+            printf("0x%02X ", as_bytes[i]);
+        putchar('\n');
+    }
+
+    module_regex = "^.*libsigscan-test-external\\.out$";
+    match        = sigscan_pid_module(pid, module_regex, signature);
+    printf("Searching in all modules of PID \"%d\", that match regex \"%s\": "
+           "%p\n",
+           pid, module_regex, match);
+
+    module_regex = "^INVALID$";
+    match        = sigscan_pid_module(pid, module_regex, signature);
+    printf("Searching in all modules of PID \"%d\", that match regex \"%s\": "
+           "%p\n",
+           pid, module_regex, match);
+
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,7 @@
 
 #include <stdio.h>
+
+#define LIBSIGSCAN_DEBUG
 #include "libsigscan.h"
 
 /* This data would be in the application we are trying to scan. */


### PR DESCRIPTION
Public changes:
- Add `sigscan_pid` and `sigscan_pid_module`.
- Add public function `sigscan_pidof`.
- Add `ESigscanPidType` enum.

Internal changes:
- Add static function `read_mem`, a wrapper for `process_vm_readv`.
- Use [buffered search](https://github.com/8dcc/scratch/blob/28e5e2a0496a98dfd78d71f3adc3951e7d239838/C/algorithms/buffered-search.c) method in `do_scan`.